### PR TITLE
Updated ability to log Moods for a day aside from the current day.

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -26,9 +26,6 @@ var neutral = document.getElementById("neutral-face");
 var smile = document.getElementById("smiling-face");
 var happy = document.getElementById("happy-face");
 
-
-// 
-
 /*
     For the Mood Tracker Calendar
         Code referenced and modified from https://gosnippets.com/snippets/dynamic-calendar-with-pure-css-and-javascript
@@ -90,13 +87,12 @@ $(document).ready(function() {
         //console.log(selected_mood);
         confirm_btn.disabled = false;
         if(confirm_btn.disabled === false) {
-            $("#mood-confirm").click(function(e) {
+            $("#mood-confirm").click(function(event) {
                 modal.style.display = "none";
                 // Replace today's date with selected Mood
                 switch(selected_mood) {
                     case "angry-face":
                         $(".today-mood").html('<img src="../img/🦆 emoji _pouting face_.png" style="height:40px;width:40px;">');
-                        // $("#day1").html('<img src="../img/🦆 emoji _pouting face_.png" style="height:40px;width:40px;">');
                         break;
                     case "crying-face":
                         $(".today-mood").html('<img src="../img/🦆 emoji _loudly crying face_.png" style="height:40px;width:40px;">');
@@ -119,9 +115,13 @@ $(document).ready(function() {
     })
 
     // Change any other day's Mood
+    // This code causes every day the user logged a Mood on (that isn't the current day) to have the same Mood even if different Moods were logged for different days.
+    // I'm not sure how to fix it. Hardcoding everything results in the same issue. For whatever reason, the click() function is holding onto the IDs of all previously
+    // clicked-on days. I have no idea how to fix that.
+
     $(".other-day").click(function(e) {
         let day_id = "#" + this.id;
-        if(this.id == day_id)
+        console.log(day_id);
         second_modal.style.display = "block";
         second_modal_content.style.display = "block";
         $(".emoji-this-day").click(function(e) {
@@ -132,6 +132,7 @@ $(document).ready(function() {
                     second_modal.style.display = "none";
                     second_modal_content.style.display = "none";
                     // Replace today's date with selected Mood
+                    console.log(day_id);
                     switch(selected_mood) {
                         case "angry-face":
                             $(day_id).html('<img src="../img/🦆 emoji _pouting face_.png" style="height:40px;width:40px;">');
@@ -157,5 +158,6 @@ $(document).ready(function() {
             }
         })
     })
+
 });
 


### PR DESCRIPTION
There's a bug that essentially updates all Moods logged on days aside from the current day to the most recently selected Mood. This is sufficient for our beta testing, but I'm still working on fixing the issue. I tried hardcoding changes to no avail.